### PR TITLE
Use default repr isntead of hill_notation

### DIFF
--- a/chemical_composition/chemical_composition.py
+++ b/chemical_composition/chemical_composition.py
@@ -164,9 +164,6 @@ class ChemicalComposition(dict):
             self[key] = 0
         return self[key]
 
-    def __repr__(self):
-        return self.hill_notation()
-
     def clear(self):
         """Resets all lookup dictionaries and self
 
@@ -265,7 +262,8 @@ class ChemicalComposition(dict):
             # Unimod Style format
             if self._unimod_parser is None:
                 self._unimod_parser = unimod_mapper.UnimodMapper(
-                    xml_file_list=self.unimod_files, add_default_files=self.add_default_files
+                    xml_file_list=self.unimod_files,
+                    add_default_files=self.add_default_files,
                 )
             self._parse_sequence_unimod_style(input_str)
         else:


### PR DESCRIPTION
The representation of the chemical composition class used to be the dictionary itself but has been changed at some point to the hill_notation.
It would be great to either change it back to the dictionary (as with this pull request) or to change it at least to the hill_notation_unimod version, since hill_notation is not an accurate description of the class (see #21).

Since I am not sure when it was changed to hill_notation, I am not sure if this change would cause any issues in packages where chemical composition is used (e.g. pyqms).